### PR TITLE
Fix rc script for OpenBSD >= 7.2

### DIFF
--- a/src/rc.d/openbsd/tuptime
+++ b/src/rc.d/openbsd/tuptime
@@ -18,11 +18,11 @@ rc_check() {
 }
 
 rc_start() {
-	${rcexec} "${daemon} -x"
+	rc_exec "${daemon} -x"
 }
 
 rc_stop() {
-	${rcexec} "${daemon} -xg"
+	rc_exec "${daemon} -xg"
 	_rc_rm_runfile
 }
 


### PR DESCRIPTION
Support for OpenBSD version 7.2 (released 20/10/2022), `$rcexec` variable replaced with an `rc_exec` function in rc.d scripts.

Signed-off-by: Laurent Cheylus <foxy@free.fr>